### PR TITLE
Enabled installation of Amazon SSM Agent by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ### 2.3.0
-*
+* Enabled installation of Amazon SSM Agent by default
 
 ### 2.2.0
 * Replace Serverspec with InSpec for testing #42

--- a/examples/user-config/sandpit.yaml
+++ b/examples/user-config/sandpit.yaml
@@ -15,6 +15,11 @@ aws:
   region: ap-southeast-2
   vpc_id: ''
   subnet_id: ''
+  # Amazon Linux AMI 2017.09.1 (HVM
+  #source_ami: ami-33996b51
+  # Amazon Linux 2 LTS Candidate AMI 2017.12.0 (HVM)  
+  #source_ami: ami-71867013
+  # RHEL-7.4_HVM
   source_ami: ami-ccecf5af
   instance_profile: S3Access
   aem_artifacts_base: s3://aem-artifacts/adobeaemcloud

--- a/provisioners/puppet/modules/config/manifests/base.pp
+++ b/provisioners/puppet/modules/config/manifests/base.pp
@@ -74,7 +74,7 @@ class config::base (
   $install_aws_cli = true,
   $install_cloudwatchlogs = true,
   $install_collectd = true,
-  $install_amazon_ssm_agent = false,
+  $install_amazon_ssm_agent = true,
   $collectd_cloudwatch_source_url = 'https://github.com/awslabs/collectd-cloudwatch/archive/master.tar.gz',
 
   $cloudwatchlogs_logfiles          = {},


### PR DESCRIPTION
Enabled the installation of the Amazon SSM Agent by default in Puppet Manifest base.pp