### PR TITLE
bigger root volume on generic packer build

### DIFF
--- a/templates/generic.json
+++ b/templates/generic.json
@@ -7,7 +7,7 @@
     "aws_security_group_id": "", 
     "no_proxy": "", 
     "aws_region": "ap-southeast-2", 
-    "root_volume_size": "10", 
+    "root_volume_size": "20", 
     "component": "", 
     "iam_instance_profile": "", 
     "ami_users": "", 


### PR DESCRIPTION
Simple simple request.. just need a bigger root volume for packer to build from bigger SOE images clients may have.