### PR TITLE
Update logpath for stack init logfiles

### DIFF
--- a/provisioners/puppet/modules/config/data/RedHat/Amazon.yaml
+++ b/provisioners/puppet/modules/config/data/RedHat/Amazon.yaml
@@ -23,8 +23,9 @@ config::base::cloudwatchlogs_logfiles:
         datetime_format: '%b %d %H:%M:%S'
     /var/log/amazon/ssm/errors.log:
         datetime_format: '%Y-%m-%d %H:%M:%S'
-    /var/log/puppet-stack-init.log:
+    /var/log/shinesolutions/puppet-stack-init.log:
         datetime_format: '%Y-%m-%d %H:%M:%S %z'
+    /var/log/shinesolutions/puppet-deploy-artifacts-init.log: {}
+
     /var/log/cloud-init-output.log: {}
     /var/log/dmesg: {}
-    /var/log/live-snapshot-backup.log: {}

--- a/provisioners/puppet/modules/config/data/RedHat/RedHat.yaml
+++ b/provisioners/puppet/modules/config/data/RedHat/RedHat.yaml
@@ -22,8 +22,9 @@ config::base::cloudwatchlogs_logfiles:
         datetime_format: '%b %d %H:%M:%S'
     /var/log/amazon/ssm/errors.log:
         datetime_format: '%Y-%m-%d %H:%M:%S'
-    /var/log/puppet-stack-init.log:
+    /var/log/shinesolutions/puppet-stack-init.log:
         datetime_format: '%Y-%m-%d %H:%M:%S %z'
+    /var/log/shinesolutions/puppet-deploy-artifacts-init.log: {}
+
     /var/log/cloud-init-output.log: {}
     /var/log/dmesg: {}
-    /var/log/live-snapshot-backup.log: {}


### PR DESCRIPTION
Update logpath for stack init logfiles to /var/log/shinesolutions.

Regarding https://github.com/shinesolutions/aem-aws-stack-builder/issues/12.