### PR TITLE
Fix 60/amazon linux 2 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+### Fixed
+- InSpec awslogs service enabled and running test #60
+- InSpec cq.pid file not exists test #60 
+
 ## [3.4.2] - 2018-12-12
 
 ### Changed

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2016-2017 Shine Solutions
+   Copyright 2016-2019 Shine Solutions
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/test/inspec/author-publish-dispatcher_spec.rb
+++ b/test/inspec/author-publish-dispatcher_spec.rb
@@ -53,7 +53,7 @@ end
 #   its('exit_status') { should eq 0 }
 # end
 
-if File.file?("/lib/systemd/system/aem-author.service")
+if File.file?('/lib/systemd/system/aem-author.service')
 
   describe file("#{aem_base}/aem/author/crx-quickstart/conf/cq.pid") do
     it { should_not exist }
@@ -118,7 +118,7 @@ end
 #   its('exit_status') { should eq 0 }
 # end
 
-if File.file?("/lib/systemd/system/aem-publish.service")
+if File.file?('/lib/systemd/system/aem-publish.service')
 
   describe file("#{aem_base}/aem/publish/crx-quickstart/conf/cq.pid") do
     it { should_not exist }

--- a/test/inspec/author-publish-dispatcher_spec.rb
+++ b/test/inspec/author-publish-dispatcher_spec.rb
@@ -53,9 +53,13 @@ end
 #   its('exit_status') { should eq 0 }
 # end
 
-# describe file("#{aem_base}/aem/author/crx-quickstart/conf/cq.pid") do
-#   it { should_not exist }
-# end
+if File.file?("/lib/systemd/system/aem-author.service")
+
+  describe file("#{aem_base}/aem/author/crx-quickstart/conf/cq.pid") do
+    it { should_not exist }
+  end
+
+end
 
 describe file('/etc/puppetlabs/puppet/author.yaml') do
   it { should be_file }
@@ -114,9 +118,13 @@ end
 #   its('exit_status') { should eq 0 }
 # end
 
-# describe file("#{aem_base}/aem/publish/crx-quickstart/conf/cq.pid") do
-#   it { should_not exist }
-# end
+if File.file?("/lib/systemd/system/aem-publish.service")
+
+  describe file("#{aem_base}/aem/publish/crx-quickstart/conf/cq.pid") do
+    it { should_not exist }
+  end
+
+end
 
 describe file('/etc/puppetlabs/puppet/publish.yaml') do
   it { should be_file }

--- a/test/inspec/author_spec.rb
+++ b/test/inspec/author_spec.rb
@@ -53,7 +53,7 @@ end
 #   its('exit_status') { should eq 0 }
 # end
 
-if File.file?("/lib/systemd/system/aem-author.service")
+if File.file?('/lib/systemd/system/aem-author.service')
 
   describe file("#{aem_base}/aem/author/crx-quickstart/conf/cq.pid") do
     it { should_not exist }

--- a/test/inspec/author_spec.rb
+++ b/test/inspec/author_spec.rb
@@ -53,9 +53,13 @@ end
 #   its('exit_status') { should eq 0 }
 # end
 
-# describe file("#{aem_base}/aem/author/crx-quickstart/conf/cq.pid") do
-#   it { should_not exist }
-# end
+if File.file?("/lib/systemd/system/aem-author.service")
+
+  describe file("#{aem_base}/aem/author/crx-quickstart/conf/cq.pid") do
+    it { should_not exist }
+  end
+
+end
 
 describe file('/etc/puppetlabs/puppet/author.yaml') do
   it { should be_file }

--- a/test/inspec/base_spec.rb
+++ b/test/inspec/base_spec.rb
@@ -57,7 +57,7 @@ end
 if install_cloudwatchlogs == true
 
   # inspec version 1.51.6. doesn't support Amazon Linux 2. It assumes it uses Upstart.
-  # inspec version is locked to 1.51.6 for the locked down train version so to not bring in the aws-sdk dependency:
+  # inspec version is locked to 1.51.6 to use train version 0.32 because it doesn't have an aws-sdk dependency:
   # https://github.com/inspec/inspec/blob/v1.51.6/inspec.gemspec#L29
   # inspec supports amazon linux 2 from version v2.1.30 (2018-04-05)
   # https://github.com/inspec/inspec/blob/master/CHANGELOG.md#v2130-2018-04-05

--- a/test/inspec/base_spec.rb
+++ b/test/inspec/base_spec.rb
@@ -56,9 +56,26 @@ end
 
 if install_cloudwatchlogs == true
 
-  describe service(@hiera.lookup('base::awslogs_service_name', nil, @scope)) do
-    it { should be_enabled }
-    it { should be_running }
+  # inspec version 1.51.6. doesn't support Amazon Linux 2. It assumes it uses Upstart.
+  # inspec version is locked to 1.51.6 for the locked down train version so to not bring in the aws-sdk dependency:
+  # https://github.com/inspec/inspec/blob/v1.51.6/inspec.gemspec#L29
+  # inspec supports amazon linux 2 from version v2.1.30 (2018-04-05)
+  # https://github.com/inspec/inspec/blob/master/CHANGELOG.md#v2130-2018-04-05
+  # remove this handling once upgraded.
+  if %w{amazon}.include?(os[:name]) && !os[:release].start_with?('20\d\d')
+
+    describe systemd_service(@hiera.lookup('base::awslogs_service_name', nil, @scope)) do
+      it { should be_enabled }
+      it { should be_running }
+    end
+
+  else
+
+    describe service(@hiera.lookup('base::awslogs_service_name', nil, @scope)) do
+      it { should be_enabled }
+      it { should be_running }
+    end
+
   end
 
   describe file('/etc/awslogs/awslogs.conf') do

--- a/test/inspec/base_spec.rb
+++ b/test/inspec/base_spec.rb
@@ -61,8 +61,8 @@ if install_cloudwatchlogs == true
   # https://github.com/inspec/inspec/blob/v1.51.6/inspec.gemspec#L29
   # inspec supports amazon linux 2 from version v2.1.30 (2018-04-05)
   # https://github.com/inspec/inspec/blob/master/CHANGELOG.md#v2130-2018-04-05
-  # remove this handling once upgraded.
-  if %w{amazon}.include?(os[:name]) && !os[:release].start_with?('20\d\d')
+  # remove this bespoke handling once upgraded.
+  if %w[amazon].include?(os[:name]) && !os[:release].start_with?('20\d\d')
 
     describe systemd_service(@hiera.lookup('base::awslogs_service_name', nil, @scope)) do
       it { should be_enabled }

--- a/test/inspec/publish_spec.rb
+++ b/test/inspec/publish_spec.rb
@@ -53,7 +53,7 @@ end
 #   its('exit_status') { should eq 0 }
 # end
 
-if File.file?("/lib/systemd/system/aem-publish.service")
+if File.file?('/lib/systemd/system/aem-publish.service')
 
   describe file("#{aem_base}/aem/publish/crx-quickstart/conf/cq.pid") do
     it { should_not exist }

--- a/test/inspec/publish_spec.rb
+++ b/test/inspec/publish_spec.rb
@@ -53,9 +53,13 @@ end
 #   its('exit_status') { should eq 0 }
 # end
 
-# describe file("#{aem_base}/aem/publish/crx-quickstart/conf/cq.pid") do
-#   it { should_not exist }
-# end
+if File.file?("/lib/systemd/system/aem-publish.service")
+
+  describe file("#{aem_base}/aem/publish/crx-quickstart/conf/cq.pid") do
+    it { should_not exist }
+  end
+
+end
 
 describe file('/etc/puppetlabs/puppet/publish.yaml') do
   it { should be_file }


### PR DESCRIPTION
InSpec version 0.32 doesn't support Amazon Linux 2. version 0.32 assumes the service manger is Upstart, and fails when check the awslogs service is enabled and running. Add a condition to check if the os is an Amazon Linux 2 and use the service_systemd resource to perform the awslogs service test.

The cq.pid file is managed by the systemd. - added a condition around the test to check if systemd is being used before executing the test.
