### PR TITLE
Lock down bundler on host gem to version 1.17.3 in order to support R…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 2.7.5
+* Lock down bundler on host gem to version 1.17.3 in order to support Ruby older than 2.3.0
+
 ### 2.7.4
 * Lock down awscli version to 1.15.41 let it determine boto dependency when awscli installation is enabled
 * Lock down boto3 version to 1.7.41

--- a/provisioners/puppet/modules/config/manifests/init.pp
+++ b/provisioners/puppet/modules/config/manifests/init.pp
@@ -27,8 +27,12 @@ class config (
   # needed for ffi (a ruby_aem dependency) native compilation
   } -> package { [ 'autoconf', 'automake', 'libtool' ]:
     ensure => installed,
-  } -> package { [ 'bundler', 'io-console' ]:
+  } -> package { 'io-console':
     provider => 'gem',
+  # TODO: upgrade to bundler >= 2.0.1 when all machine images includes Ruby >= 2.3.0
+  # This bundler is used for the initial gem installation on the host
+  } -> package { 'bundler':
+    ensure   => '1.17.3',
   } -> package { 'nokogiri':
     ensure   => '1.8.2',
     provider => 'puppet_gem',


### PR DESCRIPTION
…uby older than 2.3.0.