### PR TITLE
#131 inspec java password

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source 'https://rubygems.org'
 gem 'aws-sdk-core', '3.50.0'
 gem 'inspec', '4.3.2', require: false
 gem 'jsonlint', '0.2.0', require: false
-gem 'puppet-lint','2.3.6', require: false
+gem 'puppet-lint', '2.3.6', require: false
 gem 'r10k', '3.2.0', require: false
 gem 'rake', '12.3.2', require: false
 gem 'rubocop', '0.68.1', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -2,11 +2,11 @@
 
 source 'https://rubygems.org'
 
-gem 'aws-sdk-core', '3.47.0'
-gem 'inspec', '1.51.6', require: false
-gem 'jsonlint', require: false
-gem 'puppet-lint', require: false
-gem 'r10k', require: false
-gem 'rake', require: false
-gem 'rubocop', require: false
-gem 'yaml-lint', require: false
+gem 'aws-sdk-core', '3.50.0'
+gem 'inspec', '4.3.2', require: false
+gem 'jsonlint', '0.2.0', require: false
+gem 'puppet-lint','2.3.6', require: false
+gem 'r10k', '3.2.0', require: false
+gem 'rake', '12.3.2', require: false
+gem 'rubocop', '0.68.1', require: false
+gem 'yaml-lint', '0.0.10', require: false

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ publish:
 
 # resolve dependencies from remote artifact registries
 deps:
-	gem install bundler
+	gem install bundler --version=2.0.1
 	bundle install --binstubs
 	bundle exec r10k puppetfile install --verbose --moduledir modules
 	pip install -r requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ publish:
 
 # resolve dependencies from remote artifact registries
 deps:
-	gem install bundler --version=2.0.1
+	gem install bundler --version=1.17.3
 	bundle install --binstubs
 	bundle exec r10k puppetfile install --verbose --moduledir modules
 	pip install -r requirements.txt

--- a/provisioners/puppet/modules/config/manifests/license.pp
+++ b/provisioners/puppet/modules/config/manifests/license.pp
@@ -34,6 +34,7 @@ class config::license (
   $aem_license_base,
   $tmp_dir,
   $region,
+  $license_value = lookup("${aem_license}"),
 ) {
 
   # TODO: This code is a workaround, this needs a better conversion that can map any aem_profile into any aem_version
@@ -56,16 +57,10 @@ class config::license (
     mode   => '0700',
   }
 
-  # Download the License file from Parameter Store
-  exec { 'Download License file from AWS Systems Manager Parameter Store':
-    creates => "${tmp_dir}/license/license-${aem_version}.properties",
-    command => "aws ssm get-parameters --region ${region} --names ${aem_license} --with-decryption --output text --query Parameters[0].Value > ${tmp_dir}/license/license-${aem_version}.properties",
-    path    => '/usr/local/bin/:/bin/',
-  }
-
   file { "${tmp_dir}/license/license-${aem_version}.properties":
-    ensure => file,
-    mode   => '0644',
+    ensure  => file,
+    mode    => '0644',
+    content => $license_value,
   }
 
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,4 @@
-ansible==2.5.8
-awscli==1.16.10
-boto3==1.8.5
-#TODO: Remove the manual isort version locking when they fix this issue: https://github.com/timothycrosley/isort/issues/849
-isort==4.3.4
+ansible==2.7.10
+awscli==1.16.115
+boto3==1.9.145
 pylint==1.9.4


### PR DESCRIPTION
This commit locks down the high level dependencies for AEM Opencloud, mainly for places that have requirements around specific versions of software.

Of particular interest is the jump from inspec 1.5 to 4.3 seems to work fine and all tests run successfully (and fail appropriately). This upgrade will allow more secure string work in the future.

Ansible has also received an upgrade to the latest stable secure version and works with no issues to author, publish, dispatcher or java.