### PR TITLE
Added Secure String

### DIFF
--- a/conf/puppet/hiera.yaml
+++ b/conf/puppet/hiera.yaml
@@ -21,3 +21,4 @@ hierarchy:
     options:
       region: "%{::aws_region}"
       get_all: true
+      recursive: true

--- a/provisioners/ansible/playbooks/create-aws-resources.yaml
+++ b/provisioners/ansible/playbooks/create-aws-resources.yaml
@@ -7,6 +7,13 @@
 
   tasks:
 
+    - name: "Create AWS SSM Secure String Parameters"
+      aws_ssm_parameter_store:
+        name: "/aem-opencloud/{{ stack_prefix }}/aem-license"
+        description: "License for {{ stack_prefix }} Stack. Delete using the delete job in AEM Opencloud Manager."
+        string_type: "SecureString"
+        value: "changeme"
+
     - name: Create AWS resources stack
       cloudformation:
         stack_name: "{{ stack_prefix }}-{{ aws.resources.stack_name }}"

--- a/provisioners/ansible/playbooks/create-aws-resources.yaml
+++ b/provisioners/ansible/playbooks/create-aws-resources.yaml
@@ -12,7 +12,7 @@
         name: "/aem-opencloud/{{ stack_prefix }}/aem-license"
         description: "License for {{ stack_prefix }} Stack. Delete using the delete job in AEM Opencloud Manager."
         string_type: "SecureString"
-        value: "changeme"
+        value: "overwrite-me"
 
     - name: Create AWS resources stack
       cloudformation:

--- a/templates/cloudformation/aws-resources.yaml
+++ b/templates/cloudformation/aws-resources.yaml
@@ -41,16 +41,6 @@ Resources:
       BucketName:
         Ref: PackerAemS3Bucket
 
-  AemLicense:
-    Type: AWS::SSM::Parameter
-    Properties:
-      Value: "overwrite-me"
-      Type: String
-      Description:
-        Fn::Join: ['', ['The AEM License String for: ', Ref: 'StackPrefix']]
-      Name: 
-        Fn::Join: ['', ['/aem-opencloud/', Ref: 'StackPrefix', '/aem-license']]
-
   # TODO: Move to SecureString when it is supported on AWS Cloudformation.
   # For more information see:
   #   https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ssm-parameter.html


### PR DESCRIPTION
This PR allows Packer-AEM's "create-aws-resources" step to create the needed parameters for License and Keystore as secure strings instead of plain text. These values are secured using the default AWS KMS key ensuring encryption at rest.