### PR TITLE
Fixed bug when CreatePackerBucket is false. 

### DIFF
--- a/templates/cloudformation/aws-resources.yaml
+++ b/templates/cloudformation/aws-resources.yaml
@@ -85,7 +85,7 @@ Resources:
         - Action: ['s3:GetObject', 's3:ListBucket']
           Effect: Allow
           Resource:
-          - Fn::Join: ['', ['arn:aws:s3:::', Ref: 'PackerAemArtefactBucket']]
+          - Fn::Join: ['', ['arn:aws:s3:::', Ref: 'PackerAemS3Bucket']]
       PolicyName: PackerAemBucketPolicy
       Roles: [Ref: 'PackerAemRole']
 


### PR DESCRIPTION
PackerAemBucketPolicy reference to BucketName instead of Bucket Resource, since the resource is
not existed when CreatePackerBucket is false.