### PR TITLE
Updated Search path for secure string

### DIFF
--- a/conf/puppet/hiera.yaml
+++ b/conf/puppet/hiera.yaml
@@ -17,8 +17,8 @@ hierarchy:
   - name: "AWS Parameter Store"
     lookup_key: hiera_ssm_paramstore
     uris:
-      - /aem-opencloud/
+      - /
     options:
       region: "%{::aws_region}"
-      get_all: true
-      recursive: true
+      get_all: false
+      recursive: false


### PR DESCRIPTION
This PR fixes some issues with keys that are not stored under /aem-opencloud/ in SSM parameter store.