### PR TITLE
Missing region in aws_ssm_parameter_store module

### DIFF
--- a/provisioners/ansible/playbooks/create-aws-resources.yaml
+++ b/provisioners/ansible/playbooks/create-aws-resources.yaml
@@ -10,6 +10,7 @@
     - name: "Create AWS SSM License Secure String Parameter"
       aws_ssm_parameter_store:
         name: "/aem-opencloud/{{ stack_prefix }}/aem-license"
+        region: "{{ aws.region }}"
         description: "License for {{ stack_prefix }} Stack. Delete using the delete job in AEM Opencloud Manager."
         string_type: "SecureString"
         value: "changeme"
@@ -17,6 +18,7 @@
     - name: "Create AWS SSM Keystore Password Secure String Parameter"
       aws_ssm_parameter_store:
         name: "/aem-opencloud/{{ stack_prefix }}/aem-keystore-password"
+        region: "{{ aws.region }}"
         description: "Keystore value for {{ stack_prefix }} Stack. Delete using the delete job in AEM Opencloud Manager."
         string_type: "SecureString"
         value: "changeme"

--- a/provisioners/ansible/playbooks/delete-aws-resources.yaml
+++ b/provisioners/ansible/playbooks/delete-aws-resources.yaml
@@ -10,12 +10,14 @@
     - name: "Delete AWS SSM License Secure String Parameter"
       aws_ssm_parameter_store:
         name: "/aem-opencloud/{{ stack_prefix }}/aem-license"
+        region: "{{ aws.region }}"
         string_type: "SecureString"
         state: absent
 
     - name: "Delete AWS SSM Keystore Password Secure String Parameter"
       aws_ssm_parameter_store:
         name: "/aem-opencloud/{{ stack_prefix }}/aem-keystore-password"
+        region: "{{ aws.region }}"
         string_type: "SecureString"
         state: absent
 


### PR DESCRIPTION
Fix the error [The aws_ssm_parameter_store module requires a region and none was found in configuration, environment variables or module parameters].