### PR TITLE
Introducing packer temp security group cidr range variable

### DIFF
--- a/templates/ansible/packer-vars.j2
+++ b/templates/ansible/packer-vars.j2
@@ -17,5 +17,6 @@
   "no_proxy": "{{ no_proxy }}",
   "devicemap_root" : "{{ aws[os_type].devicemap_root }}",
   "devicemap_data_b": "{{ aws[os_type].devicemap_data_b }}",
-  "devicemap_data_c": "{{ aws[os_type].devicemap_data_c }}"
+  "devicemap_data_c": "{{ aws[os_type].devicemap_data_c }}",
+  "packer_temp_security_group_source_cidr": "{{ aws.packer_temp_security_group_source_cidr }}"
 }

--- a/templates/ansible/packer-vars.j2
+++ b/templates/ansible/packer-vars.j2
@@ -18,5 +18,5 @@
   "devicemap_root" : "{{ aws[os_type].devicemap_root }}",
   "devicemap_data_b": "{{ aws[os_type].devicemap_data_b }}",
   "devicemap_data_c": "{{ aws[os_type].devicemap_data_c }}",
-  "packer_temp_security_group_source_cidr": "{{ aws.packer_temp_security_group_source_cidr }}"
+  "temporary_security_group_source_cidr": "{{ aws.temporary_security_group_source_cidr }}"
 }

--- a/templates/packer/aws/author-publish-dispatcher.json
+++ b/templates/packer/aws/author-publish-dispatcher.json
@@ -24,7 +24,7 @@
     "os_type": "",
     "aws_user": "ec2-user",
     "packer_aem_version": "",
-    "packer_temp_security_group_source_cidr": "0.0.0.0/0"
+    "temporary_security_group_source_cidr": ""
   },
   "provisioners": [
     {
@@ -227,7 +227,7 @@
       "ami_users": "{{user `ami_users`}}",
       "type": "amazon-ebs",
       "ssh_pty": true,
-      "temporary_security_group_source_cidr": "{{ user `packer_temp_security_group_source_cidr` }}"
+      "temporary_security_group_source_cidr": "{{ user `temporary_security_group_source_cidr` }}"
     }
   ]
 }

--- a/templates/packer/aws/author-publish-dispatcher.json
+++ b/templates/packer/aws/author-publish-dispatcher.json
@@ -23,7 +23,8 @@
     "platform_type": "",
     "os_type": "",
     "aws_user": "ec2-user",
-    "packer_aem_version": ""
+    "packer_aem_version": "",
+    "packer_temp_security_group_source_cidr": "0.0.0.0/0"
   },
   "provisioners": [
     {
@@ -225,7 +226,8 @@
       ],
       "ami_users": "{{user `ami_users`}}",
       "type": "amazon-ebs",
-      "ssh_pty": true
+      "ssh_pty": true,
+      "temporary_security_group_source_cidr": "{{ user `packer_temp_security_group_source_cidr` }}"
     }
   ]
 }

--- a/templates/packer/aws/generic.json
+++ b/templates/packer/aws/generic.json
@@ -24,7 +24,7 @@
     "os_type": "",
     "aws_user": "ec2-user",
     "packer_aem_version": "",
-    "packer_temp_security_group_source_cidr": "0.0.0.0/0"
+    "temporary_security_group_source_cidr": ""
   },
   "provisioners": [
     {
@@ -215,7 +215,7 @@
       "ami_users": "{{user `ami_users`}}",
       "type": "amazon-ebs",
       "ssh_pty": true,
-      "temporary_security_group_source_cidr": "{{ user `packer_temp_security_group_source_cidr` }}"
+      "temporary_security_group_source_cidr": "{{ user `temporary_security_group_source_cidr` }}"
     }
   ]
 }

--- a/templates/packer/aws/generic.json
+++ b/templates/packer/aws/generic.json
@@ -23,7 +23,8 @@
     "instance_type": "",
     "os_type": "",
     "aws_user": "ec2-user",
-    "packer_aem_version": ""
+    "packer_aem_version": "",
+    "packer_temp_security_group_source_cidr": "0.0.0.0/0"
   },
   "provisioners": [
     {
@@ -213,7 +214,8 @@
       ],
       "ami_users": "{{user `ami_users`}}",
       "type": "amazon-ebs",
-      "ssh_pty": true
+      "ssh_pty": true,
+      "temporary_security_group_source_cidr": "{{ user `packer_temp_security_group_source_cidr` }}"
     }
   ]
 }


### PR DESCRIPTION
This is to overwrite the default security group creation, with a customised cidr range without wideopening the inbound rule