### PR TITLE
Add InSpec test to verify JDK keystore password is not `changeit` #131

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- Add InSpec test to verify JDK keystore password is not the infamous `changeit` #131
+
 ## 4.9.0 - 2019-08-16
 ### Added
 - Add AWS resources creation and deletion to integration testing

--- a/test/inspec/author-publish-dispatcher_spec.rb
+++ b/test/inspec/author-publish-dispatcher_spec.rb
@@ -10,6 +10,9 @@ aem_base ||= '/opt'
 aem_port = @hiera.lookup('author::aem_port', nil, @scope)
 aem_port ||= '4502'
 
+author_data_volume_mount_point = @hiera.lookup('aem_curator::install_author::data_volume_mount_point', nil, @scope)
+author_data_volume_mount_point ||= '/mnt/ebs1'
+
 ### SSM paramter store lookup is only supported for hiera5
 # aem_author_keystore_password = @hiera.lookup('aem_curator::install_author::aem_keystore_password', nil, @scope)
 
@@ -54,9 +57,10 @@ end
 #   it { should_not match(/changeit/) }
 # end
 
-# describe command("keytool -list -keystore #{aem_base}/aem/author/crx-quickstart/ssl/aem.ks -alias cqse -storepass #{aem_keystore_password}") do
-#   its('exit_status') { should eq 0 }
-# end
+# Test if default keystore password is not changeit
+describe command("keytool -list -keystore #{author_data_volume_mount_point}/author/crx-quickstart/ssl/aem.ks -alias cqse -storepass changeit") do
+  its('exit_status') { should_not eq 0 }
+end
 
 if File.file?('/lib/systemd/system/aem-author.service')
 
@@ -79,6 +83,9 @@ aem_base ||= '/opt'
 
 aem_port = @hiera.lookup('publish::aem_port', nil, @scope)
 aem_port ||= '4503'
+
+publish_data_volume_mount_point = @hiera.lookup('aem_curator::install_publish::data_volume_mount_point', nil, @scope)
+publish_data_volume_mount_point ||= '/mnt/ebs2'
 
 ### SSM paramter store lookup is only supported for hiera5
 # aem_publish_keystore_password = @hiera.lookup('aem_curator::install_publish::aem_keystore_password', nil, @scope)
@@ -124,9 +131,10 @@ end
 #   it { should_not match(/changeit/) }
 # end
 
-# describe command("keytool -list -keystore #{aem_base}/aem/publish/crx-quickstart/ssl/aem.ks -alias cqse -storepass #{aem_keystore_password}") do
-#   its('exit_status') { should eq 0 }
-# end
+# Test if default keystore password is changeit
+describe command("keytool -list -keystore #{publish_data_volume_mount_point}/publish/crx-quickstart/ssl/aem.ks -alias cqse -storepass changeit") do
+  its('exit_status') { should_not eq 0 }
+end
 
 if File.file?('/lib/systemd/system/aem-publish.service')
 

--- a/test/inspec/author_spec.rb
+++ b/test/inspec/author_spec.rb
@@ -10,6 +10,9 @@ aem_base ||= '/opt'
 aem_port = @hiera.lookup('author::aem_port', nil, @scope)
 aem_port ||= '4502'
 
+data_volume_mount_point = @hiera.lookup('aem_curator::install_author::data_volume_mount_point', nil, @scope)
+data_volume_mount_point ||= '/mnt/ebs1'
+
 ### SSM paramter store lookup is only supported for hiera5
 # aem_keystore_password = @hiera.lookup('aem_curator::install_author::aem_keystore_password', nil, @scope)
 
@@ -62,9 +65,10 @@ end
 #   it { should_not match(/changeit/) }
 # end
 
-# describe command("keytool -list -keystore #{aem_base}/aem/author/crx-quickstart/ssl/aem.ks -alias cqse -storepass #{aem_keystore_password}") do
-#   its('exit_status') { should eq 0 }
-# end
+# Test if default keystore password is not changeit
+describe command("keytool -list -keystore #{data_volume_mount_point}/author/crx-quickstart/ssl/aem.ks -alias cqse -storepass changeit") do
+  its('exit_status') { should_not eq 0 }
+end
 
 if File.file?('/lib/systemd/system/aem-author.service')
 

--- a/test/inspec/publish_spec.rb
+++ b/test/inspec/publish_spec.rb
@@ -10,6 +10,9 @@ aem_base ||= '/opt'
 aem_port = @hiera.lookup('publish::aem_port', nil, @scope)
 aem_port ||= '4503'
 
+data_volume_mount_point = @hiera.lookup('aem_curator::install_publish::data_volume_mount_point', nil, @scope)
+data_volume_mount_point ||= '/mnt/ebs1'
+
 ### SSM paramter store lookup is only supported for hiera5
 # aem_keystore_password = @hiera.lookup('aem_curator::install_publish::aem_keystore_password', nil, @scope)
 
@@ -62,9 +65,10 @@ end
 #   it { should_not match(/changeit/) }
 # end
 
-# describe command("keytool -list -keystore #{aem_base}/aem/publish/crx-quickstart/ssl/aem.ks -alias cqse -storepass #{aem_keystore_password}") do
-#   its('exit_status') { should eq 0 }
-# end
+# Test if default keystore password is not changeit
+describe command("keytool -list -keystore #{data_volume_mount_point}/publish/crx-quickstart/ssl/aem.ks -alias cqse -storepass changeit") do
+  its('exit_status') { should_not eq 0 }
+end
 
 if File.file?('/lib/systemd/system/aem-publish.service')
 


### PR DESCRIPTION
Add InSpec test to verify JDK keystore password is not the infamous 
`changeit` #131

With this change we will test if the password of the AEM Java Keystore `#{data_volume_mount_point}/author/crx-quickstart/ssl/aem.ks` or `#{data_volume_mount_point}/publish/crx-quickstart/ssl/aem.ks` is equal`changeit`. If so the test will fail.