### PR TITLE
Add removal of awslogs service PID file for RHEL & CentOS #192

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added "zip_url" parameter to CloudWatch Metric in order to customise the `aws-scripts-mon` repository and fix FileSystem value which been passed by it to CloudWatch dashboard.
 - Add new configuration properties `aem.jdk.base_url`, `aem.jdk.filename`, `aem.jdk.version`, `aem.jdk.version_update`
 - Add new configuration property `aem.dispatcher.ssl_version`
+- Add removal of awslogs service PID file for RHEL & CentOS #192
 
 ### Changed
 - Upgrade aem_curator to 3.2.0

--- a/conf/puppet/hieradata/RedHat/Amazon-2.yaml
+++ b/conf/puppet/hieradata/RedHat/Amazon-2.yaml
@@ -3,4 +3,5 @@
 base::python_cheetah_package: python2-cheetah
 
 base::awslogs_service_name: 'awslogsd'
-base::awslogs_proxy_path: /etc/awslogs/proxy.conf
+base::awslogs_path: /etc/awslogs
+base::awslogs_proxy_path: "%{hiera('base::awslogs_path')}/proxy.conf"

--- a/conf/puppet/hieradata/common.yaml
+++ b/conf/puppet/hieradata/common.yaml
@@ -38,4 +38,5 @@ aem_curator::install_dispatcher::apache_http_port: "80"
 aem_curator::install_dispatcher::apache_https_port: "443"
 
 base::awslogs_service_name: 'awslogs'
-base::awslogs_proxy_path: /var/awslogs/etc/proxy.conf
+base::awslogs_path: /var/awslogs
+base::awslogs_proxy_path: "%{hiera('base::awslogs_path')}/etc/proxy.conf"

--- a/provisioners/puppet/manifests/author-publish-dispatcher.pp
+++ b/provisioners/puppet/manifests/author-publish-dispatcher.pp
@@ -31,11 +31,11 @@ if $::config::base::install_cloudwatchlogs {
         path    => '/usr/bin:/usr/sbin:/bin:/usr/local/bin',
         before  =>  File["${::config::base::awslogs_path}/state/awslogs.pid"]
       } -> file {"${::config::base::awslogs_path}/state/awslogs.pid":
-        ensure => absent,
+        ensure  => absent,
         require => Exec['Stop Cloudwatchlogs agent']
       }
     }
-    default: { notify("Skipping awslogs stop and pid file removal") }
+    default: { notify('Skipping awslogs stop and pid file removal') }
   }
 }
 

--- a/provisioners/puppet/manifests/author-publish-dispatcher.pp
+++ b/provisioners/puppet/manifests/author-publish-dispatcher.pp
@@ -18,6 +18,25 @@ if $::config::base::install_cloudwatchlogs {
     aem_id => 'publish',
   }
   config::cloudwatchlogs_httpd { 'Setup CloudWatch for Dispatcher': }
+
+  # At the end of doing all Cloudwatch actions we are stopping the CloudWatch agent
+  # and removing the awslogs pid file but only on RedHat or CentOS systems.
+  #
+  # Related to https://github.com/shinesolutions/packer-aem/issues/192
+  #
+  case $::os['name'] {
+    /^(CentOS|RedHat)$/: {
+      exec { 'Stop Cloudwatchlogs agent':
+        command => "systemctl stop ${::config::base::awslogs_service_name}",
+        path    => '/usr/bin:/usr/sbin:/bin:/usr/local/bin',
+        before  =>  File["${::config::base::awslogs_path}/state/awslogs.pid"]
+      } -> file {"${::config::base::awslogs_path}/state/awslogs.pid":
+        ensure => absent,
+        require => Exec['Stop Cloudwatchlogs agent']
+      }
+    }
+    default: { notify("Skipping awslogs stop and pid file removal") }
+  }
 }
 
 include aem_curator::install_dispatcher

--- a/provisioners/puppet/manifests/author.pp
+++ b/provisioners/puppet/manifests/author.pp
@@ -25,11 +25,11 @@ if $::config::base::install_cloudwatchlogs {
         path    => '/usr/bin:/usr/sbin:/bin:/usr/local/bin',
         before  =>  File["${::config::base::awslogs_path}/state/awslogs.pid"]
       } -> file {"${::config::base::awslogs_path}/state/awslogs.pid":
-        ensure => absent,
+        ensure  => absent,
         require => Exec['Stop Cloudwatchlogs agent']
       }
     }
-    default: { notify("Skipping awslogs stop and pid file removal") }
+    default: { notify('Skipping awslogs stop and pid file removal') }
   }
 }
 

--- a/provisioners/puppet/manifests/author.pp
+++ b/provisioners/puppet/manifests/author.pp
@@ -12,6 +12,25 @@ if $::config::base::install_cloudwatchlogs {
   config::cloudwatchlogs_aem { 'Setup CloudWatch for AEM Author':
     aem_id => 'author',
   }
+
+  # At the end of doing all Cloudwatch actions we are stopping the CloudWatch agent
+  # and removing the awslogs pid file but only on RedHat or CentOS systems.
+  #
+  # Related to https://github.com/shinesolutions/packer-aem/issues/192
+  #
+  case $::os['name'] {
+    /^(CentOS|RedHat)$/: {
+      exec { 'Stop Cloudwatchlogs agent':
+        command => "systemctl stop ${::config::base::awslogs_service_name}",
+        path    => '/usr/bin:/usr/sbin:/bin:/usr/local/bin',
+        before  =>  File["${::config::base::awslogs_path}/state/awslogs.pid"]
+      } -> file {"${::config::base::awslogs_path}/state/awslogs.pid":
+        ensure => absent,
+        require => Exec['Stop Cloudwatchlogs agent']
+      }
+    }
+    default: { notify("Skipping awslogs stop and pid file removal") }
+  }
 }
 
 if $::config::base::install_collectd {
@@ -27,4 +46,3 @@ if $::config::base::install_cloudwatch_metric_agent {
     autoscaling => false
   }
 }
-

--- a/provisioners/puppet/manifests/dispatcher.pp
+++ b/provisioners/puppet/manifests/dispatcher.pp
@@ -5,6 +5,26 @@ include aem_curator::install_dispatcher
 
 if $::config::base::install_cloudwatchlogs {
   config::cloudwatchlogs_httpd { 'Setup CloudWatch for Dispatcher': }
+
+  # At the end of doing all Cloudwatch actions we are stopping the CloudWatch agent
+  # and removing the awslogs pid file but only on RedHat or CentOS systems.
+  #
+  # Related to https://github.com/shinesolutions/packer-aem/issues/192
+  #
+  case $::os['name'] {
+    /^(CentOS|RedHat)$/: {
+      exec { 'Stop Cloudwatchlogs agent':
+        command => "systemctl stop ${::config::base::awslogs_service_name}",
+        path    => '/usr/bin:/usr/sbin:/bin:/usr/local/bin',
+        before  =>  File["${::config::base::awslogs_path}/state/awslogs.pid"],
+        require => Service[$::config::base::awslogs_service_name]
+      } -> file {"${::config::base::awslogs_path}/state/awslogs.pid":
+        ensure => absent,
+        require => Exec['Stop Cloudwatchlogs agent']
+      }
+    }
+    default: { notify("Skipping awslogs stop and pid file removal") }
+  }
 }
 
 if $::config::base::install_cloudwatch_metric_agent {

--- a/provisioners/puppet/manifests/dispatcher.pp
+++ b/provisioners/puppet/manifests/dispatcher.pp
@@ -19,11 +19,11 @@ if $::config::base::install_cloudwatchlogs {
         before  =>  File["${::config::base::awslogs_path}/state/awslogs.pid"],
         require => Service[$::config::base::awslogs_service_name]
       } -> file {"${::config::base::awslogs_path}/state/awslogs.pid":
-        ensure => absent,
+        ensure  => absent,
         require => Exec['Stop Cloudwatchlogs agent']
       }
     }
-    default: { notify("Skipping awslogs stop and pid file removal") }
+    default: { notify('Skipping awslogs stop and pid file removal') }
   }
 }
 

--- a/provisioners/puppet/manifests/java.pp
+++ b/provisioners/puppet/manifests/java.pp
@@ -19,11 +19,11 @@ if $::config::base::install_cloudwatchlogs {
         path    => '/usr/bin:/usr/sbin:/bin:/usr/local/bin',
         before  =>  File["${::config::base::awslogs_path}/state/awslogs.pid"]
       } -> file {"${::config::base::awslogs_path}/state/awslogs.pid":
-        ensure => absent,
+        ensure  => absent,
         require => Exec['Stop Cloudwatchlogs agent']
       }
     }
-    default: { notify("Skipping awslogs stop and pid file removal") }
+    default: { notify('Skipping awslogs stop and pid file removal') }
   }
 }
 

--- a/provisioners/puppet/manifests/java.pp
+++ b/provisioners/puppet/manifests/java.pp
@@ -6,6 +6,25 @@ include aem_curator::install_java
 
 if $::config::base::install_cloudwatchlogs {
   config::cloudwatchlogs_java { 'Setup CloudWatch for Java': }
+
+  # At the end of doing all Cloudwatch actions we are stopping the CloudWatch agent
+  # and removing the awslogs pid file but only on RedHat or CentOS systems.
+  #
+  # Related to https://github.com/shinesolutions/packer-aem/issues/192
+  #
+  case $::os['name'] {
+    /^(CentOS|RedHat)$/: {
+      exec { 'Stop Cloudwatchlogs agent':
+        command => "systemctl stop ${::config::base::awslogs_service_name}",
+        path    => '/usr/bin:/usr/sbin:/bin:/usr/local/bin',
+        before  =>  File["${::config::base::awslogs_path}/state/awslogs.pid"]
+      } -> file {"${::config::base::awslogs_path}/state/awslogs.pid":
+        ensure => absent,
+        require => Exec['Stop Cloudwatchlogs agent']
+      }
+    }
+    default: { notify("Skipping awslogs stop and pid file removal") }
+  }
 }
 
 
@@ -19,5 +38,3 @@ if $::config::base::install_cloudwatch_metric_agent {
 }
 
 include config::tomcat
-
-

--- a/provisioners/puppet/manifests/publish.pp
+++ b/provisioners/puppet/manifests/publish.pp
@@ -25,11 +25,11 @@ if $::config::base::install_cloudwatchlogs {
         path    => '/usr/bin:/usr/sbin:/bin:/usr/local/bin',
         before  =>  File["${::config::base::awslogs_path}/state/awslogs.pid"]
       } -> file {"${::config::base::awslogs_path}/state/awslogs.pid":
-        ensure => absent,
+        ensure  => absent,
         require => Exec['Stop Cloudwatchlogs agent']
       }
     }
-    default: { notify("Skipping awslogs stop and pid file removal") }
+    default: { notify('Skipping awslogs stop and pid file removal') }
   }
 }
 

--- a/provisioners/puppet/manifests/publish.pp
+++ b/provisioners/puppet/manifests/publish.pp
@@ -12,6 +12,25 @@ if $::config::base::install_cloudwatchlogs {
   config::cloudwatchlogs_aem { 'Setup CloudWatch for AEM Publish':
     aem_id => 'publish',
   }
+
+  # At the end of doing all Cloudwatch actions we are stopping the CloudWatch agent
+  # and removing the awslogs pid file but only on RedHat or CentOS systems.
+  #
+  # Related to https://github.com/shinesolutions/packer-aem/issues/192
+  #
+  case $::os['name'] {
+    /^(CentOS|RedHat)$/: {
+      exec { 'Stop Cloudwatchlogs agent':
+        command => "systemctl stop ${::config::base::awslogs_service_name}",
+        path    => '/usr/bin:/usr/sbin:/bin:/usr/local/bin',
+        before  =>  File["${::config::base::awslogs_path}/state/awslogs.pid"]
+      } -> file {"${::config::base::awslogs_path}/state/awslogs.pid":
+        ensure => absent,
+        require => Exec['Stop Cloudwatchlogs agent']
+      }
+    }
+    default: { notify("Skipping awslogs stop and pid file removal") }
+  }
 }
 
 if $::config::base::install_collectd {

--- a/provisioners/puppet/modules/config/data/RedHat/Amazon-2.yaml
+++ b/provisioners/puppet/modules/config/data/RedHat/Amazon-2.yaml
@@ -31,4 +31,5 @@ config::tomcat::pkg_name: tomcat
 config::tomcat::srv_name: tomcat
 
 config::base::awslogs_service_name: awslogsd
-config::base::awslogs_proxy_path: /etc/awslogs/proxy.conf
+config::base::awslogs_path: /etc/awslogs
+config::base::awslogs_proxy_path: "%{hiera('config::base::awslogs_path')}/proxy.conf"

--- a/provisioners/puppet/modules/config/data/common.yaml
+++ b/provisioners/puppet/modules/config/data/common.yaml
@@ -4,7 +4,8 @@ config::base::python_pip_package: python-pip
 config::base::python_cheetah_package: python-cheetah
 config::base::tmp_dir: /tmp/shinesolutions/packer-aem
 config::base::awslogs_service_name: awslogs
-config::base::awslogs_proxy_path: /var/awslogs/etc/proxy.conf
+config::base::awslogs_path: /var/awslogs
+config::base::awslogs_proxy_path: "%{hiera('config::base::awslogs_path')}/etc/proxy.conf"
 
 config::base::metric_root_disk_path: '/'
 config::base::metric_data_disk_path: '/mnt/ebs1'

--- a/provisioners/puppet/modules/config/manifests/base.pp
+++ b/provisioners/puppet/modules/config/manifests/base.pp
@@ -77,6 +77,7 @@ class config::base (
   $python_cheetah_package,
   $awslogs_service_name,
   $awslogs_proxy_path,
+  $awslogs_path,
   $base_dir = '/opt/shinesolutions',
   $rhn_register = false,
   $disable_selinux = true,

--- a/test/inspec/base_spec.rb
+++ b/test/inspec/base_spec.rb
@@ -83,7 +83,7 @@ if install_cloudwatchlogs == true
 
   # On RHEL or CentOS we are removing the AWSLOGS PID file during the baking.
   # This test is to ensure the file does not exists
-  if %w[RedHat].include?(os[:name]) || %w[CentOS].include?(os[:name]) or
+  if %w[RedHat].include?(os[:name]) || %w[CentOS].include?(os[:name])
     describe file("#{cloudwatchlogs_base_path}/state/awslogs.pid") do
       it { should_not exist }
     end

--- a/test/inspec/base_spec.rb
+++ b/test/inspec/base_spec.rb
@@ -13,6 +13,9 @@ install_aws_cli ||= 'true'
 install_cloudwatchlogs = @hiera.lookup('config::base::install_cloudwatchlogs', nil, @scope)
 install_cloudwatchlogs ||= 'true'
 
+cloudwatchlogs_base_path = @hiera.lookup('config::base::awslogs_path', nil, @scope)
+cloudwatchlogs_base_path ||= '/var/awslogs'
+
 # install_aws_agents = @hiera.lookup('config::base::install_aws_agents', nil, @scope)
 # install_aws_agents ||= 'true'
 
@@ -66,16 +69,24 @@ if install_cloudwatchlogs == true
 
     describe systemd_service(@hiera.lookup('base::awslogs_service_name', nil, @scope)) do
       it { should be_enabled }
-      it { should be_running }
+      it { should_not be_running }
     end
 
   else
 
     describe service(@hiera.lookup('base::awslogs_service_name', nil, @scope)) do
       it { should be_enabled }
-      it { should be_running }
+      it { should_not be_running }
     end
 
+  end
+
+  # On RHEL or CentOS we are removing the AWSLOGS PID file during the baking.
+  # This test is to ensure the file does not exists
+  if %w[RedHat].include?(os[:name]) || %w[CentOS].include?(os[:name]) or
+    describe file("#{cloudwatchlogs_base_path}/state/awslogs.pid") do
+      it { should_not exist }
+    end
   end
 
   describe file('/etc/awslogs/awslogs.conf') do


### PR DESCRIPTION
This PR stops the awslogs service at the end of provisioning and removes the awslogs service pid file. Related to #192.

Log output:

```
[..]
    aws: Notice: /Stage[main]/Cloudwatchlogs/Service[awslogs]: Triggered 'refresh' from 1 event
    aws: Notice: /Stage[main]/Main/Exec[Stop Cloudwatchlogs agent]/returns: executed successfully
    aws: Info: Computing checksum on file /var/awslogs/state/awslogs.pid
    aws: Info: /Stage[main]/Main/File[/var/awslogs/state/awslogs.pid]: Filebucketed /var/awslogs/state/awslogs.pid to puppet with sum 5e7409b3e5519eff37d11f5fa5f796cb
[..]
    aws: Profile: tests from base_spec.rb (tests from base_spec.rb)
    aws: Version: (not specified)
    aws: Target:  local://
[..]
    aws:   Service awslogs
    aws:      ✔  is expected to be enabled
    aws:      ✔  is expected not to be running
    aws:   File /var/awslogs/state/awslogs.pid
    aws:      ✔  is expected not to exist
[..]
```