### PR TITLE
Move AEM SSL Keystore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+- Move AEM SSL Keystore from `crx-quickstart/ssl` to `/etc/ssl` [#209]
+
 ## 4.23.0 - 2020-03-01
 ### Added
 - Add new configuration parameter to enable/disable log configuration for Cloudwatch Agent

--- a/conf/puppet/hieradata/common.yaml
+++ b/conf/puppet/hieradata/common.yaml
@@ -18,6 +18,7 @@ aem_curator::install_author::setup_repository_volume: true
 aem_curator::install_author::data_volume_mount_point: /mnt/ebs1
 aem_curator::install_author::post_stop_sleep_secs: 300
 aem_curator::install_author::aem_license_base: "%{lookup('tmp_dir')}/license"
+aem_curator::install_author::aem_keystore_path: /etc/ssl/aem-author/author.ks
 
 aem_curator::install_publish::tmp_dir: "%{lookup('tmp_dir')}"
 aem_curator::install_publish::aem_host: localhost
@@ -28,6 +29,7 @@ aem_curator::install_publish::setup_repository_volume: true
 aem_curator::install_publish::data_volume_mount_point: /mnt/ebs1
 aem_curator::install_publish::post_stop_sleep_secs: 300
 aem_curator::install_publish::aem_license_base: "%{lookup('tmp_dir')}/license"
+aem_curator::install_publish::aem_keystore_path: /etc/ssl/aem-publish/publish.ks
 
 aem_curator::install_dispatcher::tmp_dir: "%{lookup('tmp_dir')}"
 aem_curator::install_dispatcher::cert_base_url: "file://%{lookup('tmp_dir')}/certs"

--- a/provisioners/puppet/modules/config/spec/aem_spec_helper.rb
+++ b/provisioners/puppet/modules/config/spec/aem_spec_helper.rb
@@ -86,7 +86,7 @@ shared_examples "aem" do |role, port|
   it { is_expected.to contain_archive('/tmp/aem_certs/aem.key') }
   it { is_expected.to contain_archive('/tmp/aem_certs/aem.cert') }
   it {
-    is_expected.to contain_java_ks("cqse:/opt/aem/#{role}/crx-quickstart/ssl/aem.ks")
+    is_expected.to contain_java_ks("cqse:/etc/ssl/aem-#{role}/#{role}.ks")
     .that_requires([
       'Archive[/tmp/aem_certs/aem.key]',
       'Archive[/tmp/aem_certs/aem.cert]',

--- a/test/inspec/author-publish-dispatcher_spec.rb
+++ b/test/inspec/author-publish-dispatcher_spec.rb
@@ -13,6 +13,9 @@ aem_port ||= '4502'
 author_data_volume_mount_point = @hiera.lookup('aem_curator::install_author::data_volume_mount_point', nil, @scope)
 author_data_volume_mount_point ||= '/mnt/ebs1'
 
+aem_author_keystore_path = @hiera.lookup('aem_curator::install_author::aem_keystore_path', nil, @scope)
+aem_author_keystore_path ||= '/etc/ssl/aem-author/author.ks'
+
 ### SSM paramter store lookup is only supported for hiera5
 # aem_author_keystore_password = @hiera.lookup('aem_curator::install_author::aem_keystore_password', nil, @scope)
 
@@ -57,8 +60,16 @@ end
 #   it { should_not match(/changeit/) }
 # end
 
-# Test if default keystore password is not changeit
-describe command("keytool -list -keystore #{author_data_volume_mount_point}/author/crx-quickstart/ssl/aem.ks -alias cqse -storepass changeit") do
+describe file("#{aem_author_keystore_path}") do
+  it { should be_file }
+  it { should exist }
+  its('mode') { should cmp '00640' }
+  it { should be_owned_by 'aem-author' }
+  it { should be_grouped_into 'aem-author' }
+end
+
+# Test if default keystore password is changeit
+describe command("keytool -list -keystore #{aem_author_keystore_path} -alias cqse -storepass changeit") do
   its('exit_status') { should_not eq 0 }
 end
 
@@ -86,6 +97,9 @@ aem_port ||= '4503'
 
 publish_data_volume_mount_point = @hiera.lookup('aem_curator::install_publish::data_volume_mount_point', nil, @scope)
 publish_data_volume_mount_point ||= '/mnt/ebs2'
+
+aem_publish_keystore_path = @hiera.lookup('aem_curator::install_publish::aem_keystore_path', nil, @scope)
+aem_publish_keystore_path ||= '/etc/ssl/aem-publish/publish.ks'
 
 ### SSM paramter store lookup is only supported for hiera5
 # aem_publish_keystore_password = @hiera.lookup('aem_curator::install_publish::aem_keystore_password', nil, @scope)
@@ -131,8 +145,16 @@ end
 #   it { should_not match(/changeit/) }
 # end
 
+describe file("#{aem_publish_keystore_path}") do
+  it { should be_file }
+  it { should exist }
+  its('mode') { should cmp '00640' }
+  it { should be_owned_by 'aem-publish' }
+  it { should be_grouped_into 'aem-publish' }
+end
+
 # Test if default keystore password is changeit
-describe command("keytool -list -keystore #{publish_data_volume_mount_point}/publish/crx-quickstart/ssl/aem.ks -alias cqse -storepass changeit") do
+describe command("keytool -list -keystore #{aem_publish_keystore_path} -alias cqse -storepass changeit") do
   its('exit_status') { should_not eq 0 }
 end
 

--- a/test/inspec/author-publish-dispatcher_spec.rb
+++ b/test/inspec/author-publish-dispatcher_spec.rb
@@ -10,9 +10,6 @@ aem_base ||= '/opt'
 aem_port = @hiera.lookup('author::aem_port', nil, @scope)
 aem_port ||= '4502'
 
-author_data_volume_mount_point = @hiera.lookup('aem_curator::install_author::data_volume_mount_point', nil, @scope)
-author_data_volume_mount_point ||= '/mnt/ebs1'
-
 aem_author_keystore_path = @hiera.lookup('aem_curator::install_author::aem_keystore_path', nil, @scope)
 aem_author_keystore_path ||= '/etc/ssl/aem-author/author.ks'
 
@@ -60,7 +57,7 @@ end
 #   it { should_not match(/changeit/) }
 # end
 
-describe file("#{aem_author_keystore_path}") do
+describe file(aem_author_keystore_path) do
   it { should be_file }
   it { should exist }
   its('mode') { should cmp '00640' }
@@ -94,9 +91,6 @@ aem_base ||= '/opt'
 
 aem_port = @hiera.lookup('publish::aem_port', nil, @scope)
 aem_port ||= '4503'
-
-publish_data_volume_mount_point = @hiera.lookup('aem_curator::install_publish::data_volume_mount_point', nil, @scope)
-publish_data_volume_mount_point ||= '/mnt/ebs2'
 
 aem_publish_keystore_path = @hiera.lookup('aem_curator::install_publish::aem_keystore_path', nil, @scope)
 aem_publish_keystore_path ||= '/etc/ssl/aem-publish/publish.ks'
@@ -145,7 +139,7 @@ end
 #   it { should_not match(/changeit/) }
 # end
 
-describe file("#{aem_publish_keystore_path}") do
+describe file(aem_publish_keystore_path) do
   it { should be_file }
   it { should exist }
   its('mode') { should cmp '00640' }

--- a/test/inspec/author_spec.rb
+++ b/test/inspec/author_spec.rb
@@ -10,9 +10,6 @@ aem_base ||= '/opt'
 aem_port = @hiera.lookup('author::aem_port', nil, @scope)
 aem_port ||= '4502'
 
-data_volume_mount_point = @hiera.lookup('aem_curator::install_author::data_volume_mount_point', nil, @scope)
-data_volume_mount_point ||= '/mnt/ebs1'
-
 aem_keystore_path = @hiera.lookup('aem_curator::install_author::aem_keystore_path', nil, @scope)
 aem_keystore_path ||= '/etc/ssl/aem-author/author.ks'
 
@@ -51,7 +48,7 @@ describe file("#{aem_base}/aem/author/aem-author-#{aem_port}.jar") do
   it { should be_grouped_into 'aem-author' }
 end
 
-describe file("#{aem_keystore_path}") do
+describe file(aem_keystore_path) do
   it { should be_file }
   it { should exist }
   its('mode') { should cmp '00640' }

--- a/test/inspec/author_spec.rb
+++ b/test/inspec/author_spec.rb
@@ -13,6 +13,9 @@ aem_port ||= '4502'
 data_volume_mount_point = @hiera.lookup('aem_curator::install_author::data_volume_mount_point', nil, @scope)
 data_volume_mount_point ||= '/mnt/ebs1'
 
+aem_keystore_path = @hiera.lookup('aem_curator::install_author::aem_keystore_path', nil, @scope)
+aem_keystore_path ||= '/etc/ssl/aem-author/author.ks'
+
 ### SSM paramter store lookup is only supported for hiera5
 # aem_keystore_password = @hiera.lookup('aem_curator::install_author::aem_keystore_password', nil, @scope)
 
@@ -48,7 +51,7 @@ describe file("#{aem_base}/aem/author/aem-author-#{aem_port}.jar") do
   it { should be_grouped_into 'aem-author' }
 end
 
-describe file("#{aem_base}/aem/author/crx-quickstart/ssl/aem.ks") do
+describe file("#{aem_keystore_path}") do
   it { should be_file }
   it { should exist }
   its('mode') { should cmp '00640' }
@@ -66,7 +69,7 @@ end
 # end
 
 # Test if default keystore password is not changeit
-describe command("keytool -list -keystore #{data_volume_mount_point}/author/crx-quickstart/ssl/aem.ks -alias cqse -storepass changeit") do
+describe command("keytool -list -keystore #{aem_keystore_path} -alias cqse -storepass changeit") do
   its('exit_status') { should_not eq 0 }
 end
 

--- a/test/inspec/publish_spec.rb
+++ b/test/inspec/publish_spec.rb
@@ -10,9 +10,6 @@ aem_base ||= '/opt'
 aem_port = @hiera.lookup('publish::aem_port', nil, @scope)
 aem_port ||= '4503'
 
-data_volume_mount_point = @hiera.lookup('aem_curator::install_publish::data_volume_mount_point', nil, @scope)
-data_volume_mount_point ||= '/mnt/ebs1'
-
 aem_keystore_path = @hiera.lookup('aem_curator::install_publish::aem_keystore_path', nil, @scope)
 aem_keystore_path ||= '/etc/ssl/aem-publish/publish.ks'
 
@@ -51,7 +48,7 @@ describe file("#{aem_base}/aem/publish/aem-publish-#{aem_port}.jar") do
   it { should be_grouped_into 'aem-publish' }
 end
 
-describe file("#{aem_keystore_path}") do
+describe file(aem_keystore_path) do
   it { should be_file }
   it { should exist }
   its('mode') { should cmp '00640' }

--- a/test/inspec/publish_spec.rb
+++ b/test/inspec/publish_spec.rb
@@ -13,6 +13,9 @@ aem_port ||= '4503'
 data_volume_mount_point = @hiera.lookup('aem_curator::install_publish::data_volume_mount_point', nil, @scope)
 data_volume_mount_point ||= '/mnt/ebs1'
 
+aem_keystore_path = @hiera.lookup('aem_curator::install_publish::aem_keystore_path', nil, @scope)
+aem_keystore_path ||= '/etc/ssl/aem-publish/publish.ks'
+
 ### SSM paramter store lookup is only supported for hiera5
 # aem_keystore_password = @hiera.lookup('aem_curator::install_publish::aem_keystore_password', nil, @scope)
 
@@ -48,7 +51,7 @@ describe file("#{aem_base}/aem/publish/aem-publish-#{aem_port}.jar") do
   it { should be_grouped_into 'aem-publish' }
 end
 
-describe file("#{aem_base}/aem/publish/crx-quickstart/ssl/aem.ks") do
+describe file("#{aem_keystore_path}") do
   it { should be_file }
   it { should exist }
   its('mode') { should cmp '00640' }
@@ -66,7 +69,7 @@ end
 # end
 
 # Test if default keystore password is not changeit
-describe command("keytool -list -keystore #{data_volume_mount_point}/publish/crx-quickstart/ssl/aem.ks -alias cqse -storepass changeit") do
+describe command("keytool -list -keystore #{aem_keystore_path} -alias cqse -storepass changeit") do
   its('exit_status') { should_not eq 0 }
 end
 


### PR DESCRIPTION
### Changed
- Move AEM SSL Keystore from `crx-quickstart/ssl` to `/etc/ssl` [#209]