### PR TITLE
Add volume permission to AMIs shared in the destination account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Add snapshot_users to allow destionation accounts copying shared AMIs
 
 ## 4.23.0 - 2020-03-01
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Added
-- Add snapshot_users to allow destionation accounts copying shared AMIs
+- Add snapshot_users in order to allow destination accounts to copy shared AMIs
 
 ## 4.23.0 - 2020-03-01
 ### Added

--- a/conf/ansible/inventory/group_vars/defaults.yaml
+++ b/conf/ansible/inventory/group_vars/defaults.yaml
@@ -30,6 +30,7 @@ aws:
     create_s3_bucket: true
   source_ami: overwrite-me
   ami_users: ''
+  snapshot_users: ''
   temporary_security_group_source_cidr: '0.0.0.0/0'
   instance_profile: overwrite-me
   install_ssm_agent: true

--- a/conf/packer/vars/00_default.json
+++ b/conf/packer/vars/00_default.json
@@ -1,5 +1,6 @@
 {
   "ami_users": "",
+  "snapshot_users": "",
   "aws_region": "ap-southeast-2",
   "aws_security_group_id": "",
   "aws_subnet_id": "",

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -54,6 +54,7 @@ Check out the [example configuration files](https://github.com/shinesolutions/ae
 | aws.subnet_id | [Subnet](https://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_Subnets.html) ID where Packer creation will run from | Mandatory | |
 | aws.source_ami | ID of the AMI used as the base of all component AMIs  | Mandatory | |
 | aws.ami_users | A comma-separated-value string of AWS account IDs to share the created AMIs with. Empty or undefined indicates the created AMIs won't be shared. | Optional | |
+| aws.snapshot_users | A comma-separated-value string of AWS account IDs to copy volumes from the shared AMI(s). Empty or undefined indicates the shared AMIs are not allow to be copied in any destination accounts. | Optional | |
 | aws.temporary_security_group_source_cidr | A comma-separated-value string of IPv4 CIDR blocks to be authorised access to the instance, when packer is creating a temporary security group. | Optional | `0.0.0.0/0` |
 | aws.iam_instance_profile | IAM Instance Profile name as set up in [AWS Resources](https://github.com/shinesolutions/packer-aem/blob/master/docs/aws-resources.md) | Mandatory | |
 | aws.install_ssm_agent | Set to `true` when SSM agent must be installed | Optional | `true` |

--- a/templates/ansible/packer-vars.j2
+++ b/templates/ansible/packer-vars.j2
@@ -5,6 +5,7 @@
   "aws_subnet_id": "{{ aws.subnet_id }}",
   "source_ami": "{{ aws.source_ami }}",
   "ami_users": "{{ aws.ami_users }}",
+  "snapshot_users": "{{ aws.snapshot_users }}",
   "iam_instance_profile": "{{ aws.instance_profile }}",
   "root_volume_size": "{{ aws.root_volume_size }}",
   "data_volume_size": "{{ aws.data_volume_size }}",

--- a/templates/packer/aws/author-publish-dispatcher.json
+++ b/templates/packer/aws/author-publish-dispatcher.json
@@ -8,6 +8,7 @@
     "root_volume_size": "30",
     "iam_instance_profile": "",
     "ami_users": "",
+    "snapshot_users": "",
     "https_proxy": "",
     "version": "x.x.x",
     "aws_vpc_id": "",
@@ -246,6 +247,7 @@
         }
       ],
       "ami_users": "{{user `ami_users`}}",
+      "snapshot_users": "{{ user `snapshot_users` }}",
       "type": "amazon-ebs",
       "ssh_pty": true,
       "temporary_security_group_source_cidrs": "{{ user `temporary_security_group_source_cidr` }}"

--- a/templates/packer/aws/generic.json
+++ b/templates/packer/aws/generic.json
@@ -8,6 +8,7 @@
     "root_volume_size": "30",
     "iam_instance_profile": "",
     "ami_users": "",
+    "snapshot_users": "",
     "https_proxy": "",
     "version": "x.x.x",
     "aws_vpc_id": "",
@@ -218,6 +219,7 @@
         }
       ],
       "ami_users": "{{user `ami_users`}}",
+      "snapshot_users": "{{ user `snapshot_users` }}",
       "type": "amazon-ebs",
       "ssh_pty": true,
       "temporary_security_group_source_cidrs": "{{ user `temporary_security_group_source_cidr` }}"


### PR DESCRIPTION
Add `snapshot_users` to support copying shared AMIs manually in the destination account.
Refer to #211 .