### PR TITLE
Fix 257/lockdown faraday

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # Start of AOC gitignore
 bin/
 logs/
-modules/
+/modules
 stage/
 zzz-*.*
 conf/packer/vars/*local.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- Lockdown InSpec dependency `faraday` to version `v1.9.3` [#257]
+
 ## 5.11.0 - 2021-12-22
 ### Changed
 - Upgrade `aem_curator` to 3.24.0

--- a/provisioners/puppet/modules/config/data/RedHat/Amazon-2.yaml
+++ b/provisioners/puppet/modules/config/data/RedHat/Amazon-2.yaml
@@ -14,6 +14,9 @@ config::package_manager_packages:
   - name: parallel
     version: 1.19.2
     provider: puppet_gem
+  - name: faraday
+    version: 1.9.3
+    provider: puppet_gem
   - name: inspec
     version: 1.51.6
     provider: puppet_gem

--- a/provisioners/puppet/modules/config/data/RedHat/Amazon.yaml
+++ b/provisioners/puppet/modules/config/data/RedHat/Amazon.yaml
@@ -11,6 +11,9 @@ config::package_manager_packages:
   - name: parallel
     version: 1.19.2
     provider: puppet_gem
+  - name: faraday
+    version: 1.9.3
+    provider: puppet_gem
   - name: inspec
     version: 1.51.6
     provider: puppet_gem

--- a/provisioners/puppet/modules/config/data/RedHat/CentOS-7.yaml
+++ b/provisioners/puppet/modules/config/data/RedHat/CentOS-7.yaml
@@ -14,6 +14,9 @@ config::package_manager_packages:
   - name: parallel
     version: 1.19.2
     provider: puppet_gem
+  - name: faraday
+    version: 1.9.3
+    provider: puppet_gem
   - name: inspec
     version: 1.51.6
     provider: puppet_gem

--- a/provisioners/puppet/modules/config/data/RedHat/CentOS.yaml
+++ b/provisioners/puppet/modules/config/data/RedHat/CentOS.yaml
@@ -14,6 +14,9 @@ config::package_manager_packages:
   - name: parallel
     version: 1.19.2
     provider: puppet_gem
+  - name: faraday
+    version: 1.9.3
+    provider: puppet_gem
   - name: inspec
     version: 1.51.6
     provider: puppet_gem

--- a/provisioners/puppet/modules/config/data/RedHat/RedHat.yaml
+++ b/provisioners/puppet/modules/config/data/RedHat/RedHat.yaml
@@ -14,6 +14,9 @@ config::package_manager_packages:
   - name: parallel
     version: 1.19.2
     provider: puppet_gem
+  - name: faraday
+    version: 1.9.3
+    provider: puppet_gem
   - name: inspec
     version: 1.51.6
     provider: puppet_gem


### PR DESCRIPTION
This PR includes a change to lockdown the version of the InSpec dependency `faraday` to version `1.9.3`


### Added
- Lockdown InSpec dependency `faraday` to version `v1.9.3` [#257]
